### PR TITLE
Use roxygen2's from CRAN instead of its development version

### DIFF
--- a/_episodes/04_session.md
+++ b/_episodes/04_session.md
@@ -116,16 +116,14 @@ sqrt( sum((a-b)^2)/length(b) )
 ~~~
 {: .r}
 
-We will use the `devtools` and `roxygen2` packages, which make creating packages in R relatively simple.
-First, install the `devtools` package, which will allow you to install the `roxygen2` package from GitHub ([code][]).
-
-[code]: https://github.com/klutometis/roxygen
-
+We will use the [`devtools`](https://cran.r-project.org/package=devtools) and
+[`roxygen2`](https://cran.r-project.org/package=roxygen2) packages, which make
+creating packages in R relatively simple. First, install both packages from
+CRAN:
 
 ~~~
-install.packages("devtools")
+install.packages(c("devtools", "roxygen2"))  # installations can be `c`ombined 
 library("devtools")
-install_github("klutometis/roxygen")
 library("roxygen2")
 ~~~
 {: .r}

--- a/_episodes_rmd/04_session.Rmd
+++ b/_episodes_rmd/04_session.Rmd
@@ -116,15 +116,16 @@ sqrt( sum((a-b)^2)/length(b) )
 }
 ```
 
-We will use the `devtools` and `roxygen2` packages, which make creating packages in R relatively simple.
-First, install the `devtools` package, which will allow you to install the `roxygen2` package from GitHub ([code][]).
+We will use the [`devtools`][devtools] and [`roxygen2`][roxygen2] packages,
+which make creating packages in R relatively simple. First, install both
+packages from CRAN:
 
-[code]: https://github.com/klutometis/roxygen
-
+[devtools]: https://cran.r-project.org/package=devtools 
+[roxygen2]: https://cran.r-project.org/package=roxygen2 
+ 
 ```{r, eval=FALSE}
-install.packages("devtools")
+install.packages(c("devtools", "roxygen2"))  # installations can be `c`ombined 
 library("devtools")
-install_github("klutometis/roxygen")
 library("roxygen2")
 ```
 


### PR DESCRIPTION
Sorry, about a88f000fd3ca8364d01839a52a16db74d294fbd4 & 6e55958c9a484cc12d10de468727d5e7fa8da40c :roll_eyes: I forgot that I could contribute directly here, but only wanted to _suggest_ this, because over in [`r-novice-inflammation`](https://github.com/swcarpentry/r-novice-inflammation/pull/345/files) we recently had the same update.